### PR TITLE
Меняем fetch чтобы получить жанры

### DIFF
--- a/src/js/api/fetch-all-films.js
+++ b/src/js/api/fetch-all-films.js
@@ -1,10 +1,19 @@
 import { API_KEY, BASE_URL } from './api-data';
 
+
 export async function fetchAllFilms(pageNumber) {
+  const URLgenres = `${BASE_URL}/genre/movie/list?api_key=${API_KEY}`
   const URL = `${BASE_URL}/trending/all/day?api_key=${API_KEY}&page=${pageNumber}`;
+
+  const apifetchGenres = await fetch(URLgenres)
+  const responseGenres = await apifetchGenres.json()
+  const {genres} = responseGenres;
 
   const apifetch = await fetch(URL)
   const response = await apifetch.json()
   const { results } = response;
-  return await results;
+  return  {
+    films: results,
+    genres
+  };
 }

--- a/src/js/dom/show-all-films.js
+++ b/src/js/dom/show-all-films.js
@@ -9,7 +9,15 @@ function showAllFilms(page) {
 }
 
 export function createMarkup(data) {
-  mainCardListEl.innerHTML = filmCard(data);
+  const {films, genres} = data;
+  console.log(data);
+  const filmsWithGenre = films.map(film => ({
+    ...film,
+    genres: genres.filter(genre => film.genre_ids.includes(genre.id))
+  }));
+  console.log(filmsWithGenre);
+  mainCardListEl.innerHTML = filmCard(filmsWithGenre);
+  
 }
 
 showAllFilms(homePage);


### PR DESCRIPTION
Пришлось изменить fetch. Так как чтобы получить массив с жанрами нужен еще один запрос на сервер.
Сделал так чтобы в конечном итоге нам приходил массив объектов карточек с уже существующим массивом жанров. Это упростит работу Ване.
<img width="538" alt="Снимок экрана 2021-11-11 в 11 31 24" src="https://user-images.githubusercontent.com/53469797/141274740-f0c183b2-0724-4432-bace-c3d3182b8887.png">
